### PR TITLE
Fixing issues #67

### DIFF
--- a/R/experiment.R
+++ b/R/experiment.R
@@ -10,11 +10,11 @@ make_wkdir <- function(dir, model) {
                 "\" in current directory \"", getwd(), "\".", sep = ""))
   }
 
-  if (!grepl("/", dir)) {
+  if (dir.exists(dir)) {
     i <- 0
     repeat {
       i <- i + 1
-      wk_dir <- paste0(getwd(), "/", dir, "_", i)
+      wk_dir <- paste0(dir, "_", i)
       if (!file.exists(wk_dir)) break
     }
   } else {


### PR DESCRIPTION
This pull-request proposes a solution to Marc's issue #67 . 

The function `make_wkdir` now recognize if the direction exists or not and add an "_X" if necessary only. With this improvement, it also makes no difference if there is a `/` in the argument `dir`.