### PR TITLE
Addressing Issue 78

### DIFF
--- a/R/call_gama.R
+++ b/R/call_gama.R
@@ -1,3 +1,26 @@
+#' Clean output of run_gama
+#'
+#' Remove folder `snapchot`` and the file `console-outputs` if empty.
+#'
+#' @param output_dir path to the output of gama.
+#' @noRd
+clean_output <- function(output_dir) {
+
+  # remove empty folder snapshot
+  snap_path <- paste0(output_dir, "/snapshot")
+  if (file.exists(snap_path) & length(dir(snap_path)) == 0) {
+    file.remove(snap_path)
+  }
+
+  # remove empty file console_outputs
+  path_file <- grep("console-outputs", dir(output_dir), value = TRUE)
+  path_file <- paste0(output_dir, "/", path_file)
+  out_file <- file.info(path_file)
+  empty_file <- out_file[which(out_file$size == 0), ]
+  empty_file <- rownames(empty_file)
+  file.remove(empty_file)
+}
+
 ################################################################################
 #' Run GAMA on a XML file
 #'
@@ -38,6 +61,10 @@ call_gama <- function(parameter_xml_file, hpc, output_dir = "") {
 
   if (gama_command > 0)
       stop(paste0("Gama fails to run your experiment."))
+
+  # remove empty output
+  clean_output(output_dir)
+
   return(normalizePath(dir(path = output_dir,
              pattern = "[simulation-outputs[:digit:]+]\\.xml",
              full.names = TRUE)))

--- a/R/repl.R
+++ b/R/repl.R
@@ -17,8 +17,10 @@
 #' @examples
 #' exp <- load_experiment("sir", system.file("examples", "sir.gaml",
 #'                         package = "rama"))
-#' repl(exp, times = 4)
-#' repl(exp, times = c("1" = 3, "4" = 5))
+#' exp1 <- repl(exp, times = 4)
+#'
+#' exp1$seed <- c(1:4)
+#' repl(exp1, times = c("1" = 3, "4" = 5))
 #'
 #' @export
 repl <- function(exp, times = NULL) UseMethod("repl")

--- a/man/repl.Rd
+++ b/man/repl.Rd
@@ -33,7 +33,9 @@ If both specified, \code{times} will be taken.
 \examples{
 exp <- load_experiment("sir", system.file("examples", "sir.gaml",
                         package = "rama"))
-repl(exp, times = 4)
-repl(exp, times = c("1" = 3, "4" = 5))
+exp1 <- repl(exp, times = 4)
+
+exp1$seed <- c(1:4)
+repl(exp1, times = c("1" = 3, "4" = 5))
 
 }


### PR DESCRIPTION
- check and remove the file `console-outputs` and folder `snapshot` create during `run_experiment()` if they are empty

- fix `repl()` example