### PR TITLE
Display issues #122

### DIFF
--- a/R/run_experiment.R
+++ b/R/run_experiment.R
@@ -16,7 +16,7 @@ realexp <- function(output, exp) {
   mapply(function(nbrow, obsper, df) {
     xs <- lapply(obsper, function(by) setdiff(1:nbrow, seq(1, nbrow, by)))
     ys <- sapply(paste0("^", names(xs), "$"), grep, names(df))
-    df[, ys] <- mapply(replace, df[, ys], xs, NA)
+    df[, ys] <- mapply(replace, df[, ys, drop = FALSE], xs, NA)
     return(df)
   },
   lapply(output, nrow),
@@ -48,7 +48,7 @@ retrieve_results <- function(outfile, exp) {
 
   # Tidy the output
   tmp2 <- lapply(seq_len(dim(tmp)[2]), function(x) {
-    suppressWarnings(if (is.numeric(as.numeric(tmp[, x]))) {
+    suppressWarnings(if (!is.na(as.numeric(tmp[, x]))) {
       tmp[, x] <- as.numeric(tmp[, x])
     } else {
       tmp[, x]
@@ -156,10 +156,9 @@ run_experiment <- function(exp, hpc = 1, save = FALSE, path = NULL,
     file.copy(outfiles, paste0(dir, "/output"))
 
     if (isTRUE(display)) {
-      images <- paste0(dir, "/output/images")
-      dir.create(images)
-      if (file.exists(paste0(output_dir, "/images")))
-        file.copy(paste0(output_dir, "/images"), images, recursive = TRUE)
+      if (file.exists(paste0(output_dir, "/snapshot")))
+        file.copy(paste0(output_dir, "/snapshot"), paste0(dir, "/output"),
+                  recursive = TRUE)
     }
   }
 

--- a/R/run_experiment.R
+++ b/R/run_experiment.R
@@ -98,9 +98,12 @@ create_outdir <- function(dir) {
 #' If the argument \code{display} is equal to \code{TRUE}, the argument
 #' \code{save} is automaticaly set to \code{TRUE}, a folder \code{snapshot} is
 #' add into the folder \code{output}, and contained the display output from
-#' GAMA.
+#' GAMA.\cr\cr
+#' If the object \code{exp} contains no \code{obs_rates}, the object \code{exp}
+#' is returned without calling gama. In this case, the column \code{output}
+#' is returned with \code{NA}.
 #'
-#' @param exp an XML file containing the experiment.
+#' @param exp an object of class experiment.
 #' @param hpc number of threads used by GAMA to run the experiment.
 #' @param save save the outputs to disk or not, default = FALSE.
 #' @param path directory to save the outputs, default = NULL.
@@ -114,7 +117,7 @@ create_outdir <- function(dir) {
 run_experiment <- function(exp, hpc = 1, save = FALSE, path = NULL,
                            display = FALSE, append = TRUE) {
 
-  if(all(ncol(parameters(exp)) == 0, ncol(obs_rates(exp)) == 0))
+  if (ncol(obs_rates(exp)) == 0)
     return(exp)
   if (!is.experiment(exp))
     stop("The argument \"exp\" is not an object of class \"experiment\".")

--- a/R/run_experiment.R
+++ b/R/run_experiment.R
@@ -142,7 +142,7 @@ run_experiment <- function(exp, hpc = 1, save = FALSE, path = NULL,
       i <- i + 1
       output_dir <- paste0(path, "/", name(exp), "_", i)
     }
-    warning(paste0("Outputs are saved in \"", output_dir, "\"."))
+   message(cat("Outputs are saved in \"", output_dir, "\"."))
     create_outdir(output_dir)
   } else {
     output_dir <- tempfile(tmpdir = tempdir())

--- a/R/run_experiment.R
+++ b/R/run_experiment.R
@@ -38,7 +38,7 @@ realexp <- function(output, exp) {
 #'
 #' @importFrom XML xmlToDataFrame
 #' @noRd
-retrieve_results <- function(outfile, exp) {
+retrieve_results <- function(outfile, exp, display) {
   # Extract a data frame
   tmp <- XML::xmlToDataFrame(XML::xmlParse(outfile), stringsAsFactors = F)
   # Extract names of the variable
@@ -48,9 +48,13 @@ retrieve_results <- function(outfile, exp) {
 
   # Tidy the output
   tmp2 <- lapply(seq_len(dim(tmp)[2]), function(x) {
-    suppressWarnings(if (!is.na(as.numeric(tmp[, x]))) {
+    suppressWarnings(if (all(!is.na(as.numeric(tmp[, x])))) {
       tmp[, x] <- as.numeric(tmp[, x])
     } else {
+      if (all(file.exists(paste0(dirname(outfile), "/snapshot/", tmp[,x])),
+              isTRUE(display))) {
+        tmp[, x] <- paste0(dirname(outfile), "/output/snapshot/", tmp[,x])
+      }
       tmp[, x]
     })
   })
@@ -149,7 +153,7 @@ run_experiment <- function(exp, hpc = 1, save = FALSE, path = NULL,
   outfiles <- call_gama(parameter_xml_file, hpc, output_dir)
 
   # retrieve all the variables of all the experiments:
-  out <- lapply(outfiles, retrieve_results, exp)
+  out <- lapply(outfiles, retrieve_results, exp, display)
 
   # Correct NA observations
   out <- realexp(out, exp)

--- a/man/run_experiment.Rd
+++ b/man/run_experiment.Rd
@@ -20,8 +20,7 @@ specified, current working directory is used to save the outputs.}
 
 \item{display}{output images are saved or not, default = FALSE.}
 
-\item{append}{append outputs to experiment, default = TRUE. It is not possible
-to set both \code{add_exp} and `save` as \code{FALSE}.}
+\item{append}{append outputs to experiment, default = TRUE.}
 }
 \description{
 From an \code{experiment} object, run an experiment by creating an XML file
@@ -35,9 +34,10 @@ of the experiment of the object \code{exp} is created. The folder contains
 two folder: \code{output} containing the result in XML and \code{input}
 containing the model file associated in GAML and the XML associated to the
 object `exp` inputted in the function. \cr\cr
-If the arguments \code{display} & \code{save} are equal to \code{TRUE}, a
-folder \code{images} is add into the folder \code{output}, and contained
-the display output from GAMA.
+If the argument \code{display} is equal to \code{TRUE}, the argument
+\code{save} is automaticaly set to \code{TRUE}, a folder \code{snapshot} is
+add into the folder \code{output}, and contained the display output from
+GAMA.
 }
 \examples{
 #load experiment

--- a/man/run_experiment.Rd
+++ b/man/run_experiment.Rd
@@ -8,7 +8,7 @@ run_experiment(exp, hpc = 1, save = FALSE, path = NULL,
   display = FALSE, append = TRUE)
 }
 \arguments{
-\item{exp}{an XML file containing the experiment.}
+\item{exp}{an object of class experiment.}
 
 \item{hpc}{number of threads used by GAMA to run the experiment.}
 
@@ -37,7 +37,10 @@ object `exp` inputted in the function. \cr\cr
 If the argument \code{display} is equal to \code{TRUE}, the argument
 \code{save} is automaticaly set to \code{TRUE}, a folder \code{snapshot} is
 add into the folder \code{output}, and contained the display output from
-GAMA.
+GAMA.\cr\cr
+If the object \code{exp} contains no \code{obs_rates}, the object \code{exp}
+is returned without calling gama. In this case, the column \code{output}
+is returned with \code{NA}.
 }
 \examples{
 #load experiment


### PR DESCRIPTION
Add display to output of 'run_experiment':
 - Add filename (absolute path if `display = TRUE`) to the obs_rates display column in the output of the object experiment
- Update attribute `path` to the.xml file linked to each data frame outputted by simulation
- Save the image outputted in a folder `output/snapshot` if `display  = TRUE`
- Add if `display = TRUE`, set automatically `save = TRUE`
- Update documentation of the function